### PR TITLE
Modificación en descuentos, se evita tener el campo base = 0

### DIFF
--- a/blockfactura/controllers/front/process.php
+++ b/blockfactura/controllers/front/process.php
@@ -311,7 +311,7 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
         //$products_invoice = Cookies::getCookie('order');
         $products_invoice = array();
         $flag_discount = false;
-
+        $emptyDiscount = false;  //bandera para indicar que hay descuento a aplicar
         $order_id = (int) $this->context->cookie->Order;
         $discount = (float) $this->context->cookie->Discount;
         $order = new Order($order_id);
@@ -356,11 +356,13 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
                     $set_discount = 0;
                     $flag_discount = true;
                 } else if ($discount > $unit_price * $product['product_quantity']){
-                    $set_discount = $unit_price * $product['product_quantity'];
-                    $discount -= $unit_price * $product['product_quantity'];
+                    $set_discount = ($unit_price * $product['product_quantity'])-0.01; //se evita tener campo base traslado igual a 0
+                    $discount -= ($unit_price * $product['product_quantity'])-0.01;
+                    $emptyDiscount = true;
                 } else {
                     $set_discount = $discount;
                     $discount = 0;
+                    $emptyDiscount = true;
                 }
             }
          
@@ -409,6 +411,9 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
             $in++;
         }
 
+        if($discount > 0 && $emptyDiscount){
+            return die(Tools::jsonEncode(array('response' => 'error', 'message' => 'El descuento no debe ser mayor al subtotal')));
+        }
         //método para obtener los gastos de envío
         $data = trim(Tools::getValue('order'));
         $query = new DbQuery();

--- a/blockfactura/controllers/front/process.php
+++ b/blockfactura/controllers/front/process.php
@@ -359,6 +359,10 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
                     $set_discount = ($unit_price * $product['product_quantity'])-0.01; //se evita tener campo base traslado igual a 0
                     $discount -= ($unit_price * $product['product_quantity'])-0.01;
                     $emptyDiscount = true;
+                } else if($discount == $unit_price * $product['product_quantity']){
+                    $set_discount = ($unit_price * $product['product_quantity'])-0.01; //se evita tener campo base traslado igual a 0
+                    $discount = 0;
+                    $emptyDiscount = true;
                 } else {
                     $set_discount = $discount;
                     $discount = 0;


### PR DESCRIPTION
Se modificó la parte de descuentos para que el descuento tome casi el valor total de cada producto (en caso de que éste sea mayor), esto con el fin de evitar el error de timbrado de ‘El valor campo base que corresponde a Traslado debe ser mayor que cero’.